### PR TITLE
Resolved: Problem with View Update after Item Deletion

### DIFF
--- a/Personal/AppleMarketApp/app/src/main/java/com/example/applemarketapp/MainActivity.kt
+++ b/Personal/AppleMarketApp/app/src/main/java/com/example/applemarketapp/MainActivity.kt
@@ -183,6 +183,7 @@ class MainActivity : AppCompatActivity() {
                 ad.setPositiveButton("확인") { _, _ ->
                     dataList.removeAt(position)
                     adapter.notifyItemRemoved(position)
+                    adapter.notifyItemRangeChanged(position, dataList.size - position)
                 }
                 ad.setNegativeButton("취소") { dialog, _ ->
                     dialog.dismiss()


### PR DESCRIPTION
The problem occurred when a product was deleted from the list, causing the view to not update correctly and resulting in an 'IndexOutOfBoundsException' error. The root cause of this issue was an incorrect range used in the 'notifyItemRangeChanged' method.

In this commit, the problem has been resolved by providing the correct range to the 'notifyItemRangeChanged' method. Now, after a product is deleted, the adapter is properly refreshed.

Closes #22 